### PR TITLE
Revert back to .NET 6

### DIFF
--- a/serilog/Dockerfile
+++ b/serilog/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 WORKDIR /dotnetapp
 

--- a/serilog/serilog-example.csproj
+++ b/serilog/serilog-example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />


### PR DESCRIPTION
# Description

Revert back to .NET 6.

.NET 7 is only in preview but their Docker images are not labeled as previews, thus Renovate is triggered to create a PR.

For more information, please see [dotnet-docker#3531](https://github.com/dotnet/dotnet-docker/issues/3531).
